### PR TITLE
Replace last scipy.misc.resize with skimage resize

### DIFF
--- a/model.py
+++ b/model.py
@@ -2596,7 +2596,7 @@ def parse_image_meta_graph(meta):
 
 
 def mold_image(images, config):
-    """Takes RGB images with 0-255 values and subtraces
+    """Expects an RGB image (or array of images) and subtraces
     the mean pixel and converts it to float. Expects image
     colors in RGB order.
     """

--- a/utils.py
+++ b/utils.py
@@ -13,7 +13,7 @@ import math
 import random
 import numpy as np
 import tensorflow as tf
-import scipy.misc
+import scipy
 import skimage.color
 import skimage.io
 import skimage.transform
@@ -425,10 +425,11 @@ def resize_image(image, min_dim=None, max_dim=None, mode="square"):
         image_max = max(h, w)
         if round(image_max * scale) > max_dim:
             scale = max_dim / image_max
-    # Resize image and mask
+    # Resize image using bilinear interpolation
     if scale != 1:
-        image = scipy.misc.imresize(
-            image, (round(h * scale), round(w * scale)))
+        image = skimage.transform.resize(
+            image, (round(h * scale), round(w * scale)),
+            order=1, mode="constant", preserve_range=True)
     # Need padding?
     if mode == "square":
         # Get new height and width


### PR DESCRIPTION
This also changes utils.resize_image() such that
it doesn’t convert images to 0-255 range, but
rather keep the input range. This would only
affect users who use input image of range 0-1
rather than 0-255.